### PR TITLE
feat: distinguish between ContractNotFound and BytecodeMissing errors

### DIFF
--- a/src/internal/sender/Deployer.sol
+++ b/src/internal/sender/Deployer.sol
@@ -63,7 +63,8 @@ library Deployer {
     ICreateX private constant CREATEX = ICreateX(CREATEX_ADDRESS);
 
     // Keccak256 hashes of known vm.getCode error messages
-    bytes32 private constant NO_BYTECODE_HASH = keccak256("vm.getCode: no bytecode for contract; is it abstract or unlinked?");
+    bytes32 private constant NO_BYTECODE_HASH =
+        keccak256("vm.getCode: no bytecode for contract; is it abstract or unlinked?");
     bytes32 private constant NO_ARTIFACT_HASH = keccak256("vm.getCode: no matching artifact found");
 
     // Custom errors for better gas efficiency and clarity

--- a/test/helpers/SendersTestHarness.sol
+++ b/test/helpers/SendersTestHarness.sol
@@ -21,9 +21,7 @@ contract SendersTestHarness is SenderCoordinator {
     using Deployer for Senders.Sender;
     using Deployer for Deployer.Deployment;
 
-    constructor(
-        Senders.SenderInitConfig[] memory _configs
-    ) SenderCoordinator(_configs, "default", false, false) {
+    constructor(Senders.SenderInitConfig[] memory _configs) SenderCoordinator(_configs, "default", false, false) {
         // Deploy MultiSendCallOnly for testing (after initialize)
         MultiSendCallOnly multiSendCallOnly = new MultiSendCallOnly();
 
@@ -32,22 +30,14 @@ contract SendersTestHarness is SenderCoordinator {
             if (_configs[i].senderType == SenderTypes.GnosisSafe) {
                 // Get the Safe.Client storage for this sender
                 Senders.Sender storage sender = Senders.get(_configs[i].name);
-                GnosisSafe.Sender storage gnosisSafeSender = GnosisSafe.cast(
-                    sender
-                );
+                GnosisSafe.Sender storage gnosisSafeSender = GnosisSafe.cast(sender);
                 Safe.Client storage safeClient = gnosisSafeSender.safe();
                 safeClient.instance().urls[block.chainid] = "https://localhost";
-                safeClient.instance().multiSendCallOnly[
-                    block.chainid
-                ] = multiSendCallOnly;
+                safeClient.instance().multiSendCallOnly[block.chainid] = multiSendCallOnly;
 
                 // Mock Safe contract calls
                 address safeAddress = sender.account;
-                vm.mockCall(
-                    safeAddress,
-                    abi.encodeWithSignature("nonce()"),
-                    abi.encode(uint256(0))
-                );
+                vm.mockCall(safeAddress, abi.encodeWithSignature("nonce()"), abi.encode(uint256(0)));
                 vm.mockCall(
                     safeAddress,
                     abi.encodeWithSignature(
@@ -66,71 +56,55 @@ contract SendersTestHarness is SenderCoordinator {
         _broadcast();
     }
 
-    function execute(
-        string memory _name,
-        Transaction memory _transaction
-    ) public returns (SimulatedTransaction memory) {
+    function execute(string memory _name, Transaction memory _transaction)
+        public
+        returns (SimulatedTransaction memory)
+    {
         return Senders.get(_name).execute(_transaction);
     }
 
-    function execute(
-        string memory _name,
-        Transaction[] memory _transactions
-    ) public returns (SimulatedTransaction[] memory) {
+    function execute(string memory _name, Transaction[] memory _transactions)
+        public
+        returns (SimulatedTransaction[] memory)
+    {
         return Senders.get(_name).execute(_transactions);
     }
 
-    function get(
-        string memory _name
-    ) public view returns (Senders.Sender memory) {
+    function get(string memory _name) public view returns (Senders.Sender memory) {
         return Senders.get(_name);
     }
 
-    function getSenderAccount(
-        string memory _name
-    ) public view returns (address) {
+    function getSenderAccount(string memory _name) public view returns (address) {
         return Senders.get(_name).account;
     }
 
-    function getPrivateKey(
-        string memory _name
-    ) public view returns (PrivateKey.Sender memory) {
+    function getPrivateKey(string memory _name) public view returns (PrivateKey.Sender memory) {
         return Senders.get(_name).privateKey();
     }
 
-    function getGnosisSafe(
-        string memory _name
-    ) public view returns (GnosisSafe.Sender memory) {
+    function getGnosisSafe(string memory _name) public view returns (GnosisSafe.Sender memory) {
         return Senders.get(_name).gnosisSafe();
     }
 
-    function getHardwareWallet(
-        string memory _name
-    ) public view returns (HardwareWallet.Sender memory) {
+    function getHardwareWallet(string memory _name) public view returns (HardwareWallet.Sender memory) {
         return Senders.get(_name).hardwareWallet();
     }
 
-    function getInMemory(
-        string memory _name
-    ) public view returns (InMemory.Sender memory) {
+    function getInMemory(string memory _name) public view returns (InMemory.Sender memory) {
         return Senders.get(_name).inMemory();
     }
 
-    function isType(
-        string memory _name,
-        bytes8 _senderType
-    ) public view returns (bool) {
+    function isType(string memory _name, bytes8 _senderType) public view returns (bool) {
         return Senders.get(_name).isType(_senderType);
     }
 
     // ************* Deployer Methods ************* //
 
     // Factory pattern methods only
-    function deployCreate3WithArtifact(
-        string memory _name,
-        string memory _artifact,
-        bytes memory _args
-    ) public returns (address) {
+    function deployCreate3WithArtifact(string memory _name, string memory _artifact, bytes memory _args)
+        public
+        returns (address)
+    {
         // Use factory pattern: create3 -> deploy
         return Senders.get(_name).create3(_artifact).deploy(_args);
     }
@@ -142,10 +116,7 @@ contract SendersTestHarness is SenderCoordinator {
         bytes memory _args
     ) public returns (address) {
         // Use factory pattern: create3 -> setLabel -> deploy
-        return
-            Senders.get(_name).create3(_artifact).setLabel(_label).deploy(
-                _args
-            );
+        return Senders.get(_name).create3(_artifact).setLabel(_label).deploy(_args);
     }
 
     function deployCreate3WithEntropy(
@@ -161,11 +132,10 @@ contract SendersTestHarness is SenderCoordinator {
     // ************* Prediction Methods ************* //
 
     // Mirror deployCreate3WithArtifact
-    function predictCreate3WithArtifact(
-        string memory _name,
-        string memory _artifact,
-        bytes memory _args
-    ) public returns (address) {
+    function predictCreate3WithArtifact(string memory _name, string memory _artifact, bytes memory _args)
+        public
+        returns (address)
+    {
         return Senders.get(_name).create3(_artifact).predict(_args);
     }
 
@@ -176,10 +146,7 @@ contract SendersTestHarness is SenderCoordinator {
         string memory _label,
         bytes memory _args
     ) public returns (address) {
-        return
-            Senders.get(_name).create3(_artifact).setLabel(_label).predict(
-                _args
-            );
+        return Senders.get(_name).create3(_artifact).setLabel(_label).predict(_args);
     }
 
     // Mirror deployCreate3WithEntropy
@@ -194,11 +161,10 @@ contract SendersTestHarness is SenderCoordinator {
 
     // ************* CREATE2 Deployer Methods ************* //
 
-    function deployCreate2WithArtifact(
-        string memory _name,
-        string memory _artifact,
-        bytes memory _args
-    ) public returns (address) {
+    function deployCreate2WithArtifact(string memory _name, string memory _artifact, bytes memory _args)
+        public
+        returns (address)
+    {
         // Use factory pattern: create2 -> deploy
         return Senders.get(_name).create2(_artifact).deploy(_args);
     }
@@ -210,10 +176,7 @@ contract SendersTestHarness is SenderCoordinator {
         bytes memory _args
     ) public returns (address) {
         // Use factory pattern: create2 -> setLabel -> deploy
-        return
-            Senders.get(_name).create2(_artifact).setLabel(_label).deploy(
-                _args
-            );
+        return Senders.get(_name).create2(_artifact).setLabel(_label).deploy(_args);
     }
 
     function deployCreate2WithEntropy(
@@ -228,11 +191,10 @@ contract SendersTestHarness is SenderCoordinator {
 
     // ************* CREATE2 Prediction Methods ************* //
 
-    function predictCreate2WithArtifact(
-        string memory _name,
-        string memory _artifact,
-        bytes memory _args
-    ) public returns (address) {
+    function predictCreate2WithArtifact(string memory _name, string memory _artifact, bytes memory _args)
+        public
+        returns (address)
+    {
         return Senders.get(_name).create2(_artifact).predict(_args);
     }
 
@@ -242,10 +204,7 @@ contract SendersTestHarness is SenderCoordinator {
         string memory _label,
         bytes memory _args
     ) public returns (address) {
-        return
-            Senders.get(_name).create2(_artifact).setLabel(_label).predict(
-                _args
-            );
+        return Senders.get(_name).create2(_artifact).setLabel(_label).predict(_args);
     }
 
     function predictCreate2WithEntropy(
@@ -257,17 +216,11 @@ contract SendersTestHarness is SenderCoordinator {
         return Senders.get(_name).create2(_entropy, _bytecode).predict(_args);
     }
 
-    function _salt(
-        string memory _name,
-        string memory _entropy
-    ) public view returns (bytes32) {
+    function _salt(string memory _name, string memory _entropy) public view returns (bytes32) {
         return Senders.get(_name)._salt(_entropy);
     }
 
-    function _derivedSalt(
-        string memory _name,
-        bytes32 _baseSalt
-    ) public view returns (bytes32) {
+    function _derivedSalt(string memory _name, bytes32 _baseSalt) public view returns (bytes32) {
         return Senders.get(_name)._derivedSalt(_baseSalt);
     }
 
@@ -283,10 +236,7 @@ contract SendersTestHarness is SenderCoordinator {
 
     // ************* Harness Helpers ************* //
 
-    function getHarness(
-        string memory _name,
-        address _target
-    ) public returns (address) {
+    function getHarness(string memory _name, address _target) public returns (address) {
         return Senders.get(_name).harness(_target);
     }
 }

--- a/test/helpers/SendersTestHarness.sol
+++ b/test/helpers/SendersTestHarness.sol
@@ -21,7 +21,9 @@ contract SendersTestHarness is SenderCoordinator {
     using Deployer for Senders.Sender;
     using Deployer for Deployer.Deployment;
 
-    constructor(Senders.SenderInitConfig[] memory _configs) SenderCoordinator(_configs, "default", false, false) {
+    constructor(
+        Senders.SenderInitConfig[] memory _configs
+    ) SenderCoordinator(_configs, "default", false, false) {
         // Deploy MultiSendCallOnly for testing (after initialize)
         MultiSendCallOnly multiSendCallOnly = new MultiSendCallOnly();
 
@@ -30,14 +32,22 @@ contract SendersTestHarness is SenderCoordinator {
             if (_configs[i].senderType == SenderTypes.GnosisSafe) {
                 // Get the Safe.Client storage for this sender
                 Senders.Sender storage sender = Senders.get(_configs[i].name);
-                GnosisSafe.Sender storage gnosisSafeSender = GnosisSafe.cast(sender);
+                GnosisSafe.Sender storage gnosisSafeSender = GnosisSafe.cast(
+                    sender
+                );
                 Safe.Client storage safeClient = gnosisSafeSender.safe();
                 safeClient.instance().urls[block.chainid] = "https://localhost";
-                safeClient.instance().multiSendCallOnly[block.chainid] = multiSendCallOnly;
+                safeClient.instance().multiSendCallOnly[
+                    block.chainid
+                ] = multiSendCallOnly;
 
                 // Mock Safe contract calls
                 address safeAddress = sender.account;
-                vm.mockCall(safeAddress, abi.encodeWithSignature("nonce()"), abi.encode(uint256(0)));
+                vm.mockCall(
+                    safeAddress,
+                    abi.encodeWithSignature("nonce()"),
+                    abi.encode(uint256(0))
+                );
                 vm.mockCall(
                     safeAddress,
                     abi.encodeWithSignature(
@@ -56,55 +66,71 @@ contract SendersTestHarness is SenderCoordinator {
         _broadcast();
     }
 
-    function execute(string memory _name, Transaction memory _transaction)
-        public
-        returns (SimulatedTransaction memory)
-    {
+    function execute(
+        string memory _name,
+        Transaction memory _transaction
+    ) public returns (SimulatedTransaction memory) {
         return Senders.get(_name).execute(_transaction);
     }
 
-    function execute(string memory _name, Transaction[] memory _transactions)
-        public
-        returns (SimulatedTransaction[] memory)
-    {
+    function execute(
+        string memory _name,
+        Transaction[] memory _transactions
+    ) public returns (SimulatedTransaction[] memory) {
         return Senders.get(_name).execute(_transactions);
     }
 
-    function get(string memory _name) public view returns (Senders.Sender memory) {
+    function get(
+        string memory _name
+    ) public view returns (Senders.Sender memory) {
         return Senders.get(_name);
     }
 
-    function getSenderAccount(string memory _name) public view returns (address) {
+    function getSenderAccount(
+        string memory _name
+    ) public view returns (address) {
         return Senders.get(_name).account;
     }
 
-    function getPrivateKey(string memory _name) public view returns (PrivateKey.Sender memory) {
+    function getPrivateKey(
+        string memory _name
+    ) public view returns (PrivateKey.Sender memory) {
         return Senders.get(_name).privateKey();
     }
 
-    function getGnosisSafe(string memory _name) public view returns (GnosisSafe.Sender memory) {
+    function getGnosisSafe(
+        string memory _name
+    ) public view returns (GnosisSafe.Sender memory) {
         return Senders.get(_name).gnosisSafe();
     }
 
-    function getHardwareWallet(string memory _name) public view returns (HardwareWallet.Sender memory) {
+    function getHardwareWallet(
+        string memory _name
+    ) public view returns (HardwareWallet.Sender memory) {
         return Senders.get(_name).hardwareWallet();
     }
 
-    function getInMemory(string memory _name) public view returns (InMemory.Sender memory) {
+    function getInMemory(
+        string memory _name
+    ) public view returns (InMemory.Sender memory) {
         return Senders.get(_name).inMemory();
     }
 
-    function isType(string memory _name, bytes8 _senderType) public view returns (bool) {
+    function isType(
+        string memory _name,
+        bytes8 _senderType
+    ) public view returns (bool) {
         return Senders.get(_name).isType(_senderType);
     }
 
     // ************* Deployer Methods ************* //
 
     // Factory pattern methods only
-    function deployCreate3WithArtifact(string memory _name, string memory _artifact, bytes memory _args)
-        public
-        returns (address)
-    {
+    function deployCreate3WithArtifact(
+        string memory _name,
+        string memory _artifact,
+        bytes memory _args
+    ) public returns (address) {
         // Use factory pattern: create3 -> deploy
         return Senders.get(_name).create3(_artifact).deploy(_args);
     }
@@ -116,7 +142,10 @@ contract SendersTestHarness is SenderCoordinator {
         bytes memory _args
     ) public returns (address) {
         // Use factory pattern: create3 -> setLabel -> deploy
-        return Senders.get(_name).create3(_artifact).setLabel(_label).deploy(_args);
+        return
+            Senders.get(_name).create3(_artifact).setLabel(_label).deploy(
+                _args
+            );
     }
 
     function deployCreate3WithEntropy(
@@ -132,10 +161,11 @@ contract SendersTestHarness is SenderCoordinator {
     // ************* Prediction Methods ************* //
 
     // Mirror deployCreate3WithArtifact
-    function predictCreate3WithArtifact(string memory _name, string memory _artifact, bytes memory _args)
-        public
-        returns (address)
-    {
+    function predictCreate3WithArtifact(
+        string memory _name,
+        string memory _artifact,
+        bytes memory _args
+    ) public returns (address) {
         return Senders.get(_name).create3(_artifact).predict(_args);
     }
 
@@ -146,7 +176,10 @@ contract SendersTestHarness is SenderCoordinator {
         string memory _label,
         bytes memory _args
     ) public returns (address) {
-        return Senders.get(_name).create3(_artifact).setLabel(_label).predict(_args);
+        return
+            Senders.get(_name).create3(_artifact).setLabel(_label).predict(
+                _args
+            );
     }
 
     // Mirror deployCreate3WithEntropy
@@ -159,11 +192,82 @@ contract SendersTestHarness is SenderCoordinator {
         return Senders.get(_name).create3(_entropy, _bytecode).predict(_args);
     }
 
-    function _salt(string memory _name, string memory _entropy) public view returns (bytes32) {
+    // ************* CREATE2 Deployer Methods ************* //
+
+    function deployCreate2WithArtifact(
+        string memory _name,
+        string memory _artifact,
+        bytes memory _args
+    ) public returns (address) {
+        // Use factory pattern: create2 -> deploy
+        return Senders.get(_name).create2(_artifact).deploy(_args);
+    }
+
+    function deployCreate2WithArtifactAndLabel(
+        string memory _name,
+        string memory _artifact,
+        string memory _label,
+        bytes memory _args
+    ) public returns (address) {
+        // Use factory pattern: create2 -> setLabel -> deploy
+        return
+            Senders.get(_name).create2(_artifact).setLabel(_label).deploy(
+                _args
+            );
+    }
+
+    function deployCreate2WithEntropy(
+        string memory _name,
+        string memory _entropy,
+        bytes memory _bytecode,
+        bytes memory _args
+    ) public returns (address) {
+        // Use factory pattern: create2 with entropy -> deploy
+        return Senders.get(_name).create2(_entropy, _bytecode).deploy(_args);
+    }
+
+    // ************* CREATE2 Prediction Methods ************* //
+
+    function predictCreate2WithArtifact(
+        string memory _name,
+        string memory _artifact,
+        bytes memory _args
+    ) public returns (address) {
+        return Senders.get(_name).create2(_artifact).predict(_args);
+    }
+
+    function predictCreate2WithArtifactAndLabel(
+        string memory _name,
+        string memory _artifact,
+        string memory _label,
+        bytes memory _args
+    ) public returns (address) {
+        return
+            Senders.get(_name).create2(_artifact).setLabel(_label).predict(
+                _args
+            );
+    }
+
+    function predictCreate2WithEntropy(
+        string memory _name,
+        string memory _entropy,
+        bytes memory _bytecode,
+        bytes memory _args
+    ) public returns (address) {
+        return Senders.get(_name).create2(_entropy, _bytecode).predict(_args);
+    }
+
+    function _salt(
+        string memory _name,
+        string memory _entropy
+    ) public view returns (bytes32) {
         return Senders.get(_name)._salt(_entropy);
     }
 
-    function _derivedSalt(string memory _name, bytes32 _baseSalt) public view returns (bytes32) {
+    function _derivedSalt(
+        string memory _name,
+        bytes32 _baseSalt
+    ) public view returns (bytes32) {
         return Senders.get(_name)._derivedSalt(_baseSalt);
     }
 
@@ -179,7 +283,10 @@ contract SendersTestHarness is SenderCoordinator {
 
     // ************* Harness Helpers ************* //
 
-    function getHarness(string memory _name, address _target) public returns (address) {
+    function getHarness(
+        string memory _name,
+        address _target
+    ) public returns (address) {
         return Senders.get(_name).harness(_target);
     }
 }


### PR DESCRIPTION
## Summary
- Add new `BytecodeMissing` error to distinguish abstract/unlinked contracts from missing artifacts
- Implement keccak256 hash-based error message matching for gas efficiency
- Add comprehensive test coverage for error scenarios

## Changes
- **New Error Type**: Added `BytecodeMissing(string what)` error in `Deployer.sol`
- **Error Detection**: Use keccak256 hashes to match vm.getCode error messages:
  - `NO_BYTECODE_HASH`: "vm.getCode: no bytecode for contract; is it abstract or unlinked?"
  - `NO_ARTIFACT_HASH`: "vm.getCode: no matching artifact found"
- **Error Handling**: Updated `create3` and `create2` functions to catch and distinguish between error types
- **Test Coverage**: Added comprehensive tests including:
  - Abstract contract fixtures
  - Unlinked library fixtures (with external dependencies)
  - Tests for both CREATE3 and CREATE2 deployment methods
  - Success cases for concrete contracts

## Motivation
This change helps detect unlinked bytecode scenarios and allows the system to potentially trigger library deployments when encountering unlinked bytecode, rather than treating all failures as missing contracts.

## Test Plan
- [x] Added test fixtures for abstract contracts and unlinked libraries
- [x] Added tests for ContractNotFound errors (non-existent artifacts)
- [x] Added tests for BytecodeMissing errors (abstract/unlinked contracts)
- [x] Added tests for successful deployments
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new methods for deploying and predicting contract addresses using CREATE2, providing more deployment options and flexibility.
* **Bug Fixes**
  * Improved error messages for missing bytecode or artifacts during contract deployment, offering clearer feedback when deployment fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->