### PR TITLE
Remove Alfajores, add Sepolia, remove env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-SEPOLIA_RPC_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: stable
 
       - name: Check formatting
         run: forge fmt --check

--- a/foundry.toml
+++ b/foundry.toml
@@ -21,6 +21,5 @@ ffi = true
 
 # RPC endpoints
 [rpc_endpoints]
-sepolia = "${SEPOLIA_RPC_URL}"
-alfajores = "https://alfajores-forno.celo-testnet.org"
+sepolia = "https://forno.celo-sepolia.celo-testnet.org"
 anvil = "http://127.0.0.1:8545"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched default testnet RPC to Celo Sepolia and removed the Alfajores entry.
  * Simplified environment example by removing an unused RPC placeholder.
  * Stabilized CI by switching the Foundry toolchain from nightly to stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->