### PR TITLE
feat: add addressbook lookup to Registry

### DIFF
--- a/script/ExampleDeploy.sol
+++ b/script/ExampleDeploy.sol
@@ -29,6 +29,7 @@ contract ExampleDeploy is ConfigurableTrebScript, CreateXScript {
             "example", // Namespace
             "sepolia",
             "example-registry.json", // Registry file
+            "example-addressbook.json", // Addressbook file
             false, // Not dry run
             false // Not quiet mode
         )

--- a/src/ConfigurableTrebScript.sol
+++ b/src/ConfigurableTrebScript.sol
@@ -55,7 +55,11 @@ abstract contract ConfigurableTrebScript is SenderCoordinator, Registry {
         string memory namespace,
         string memory network,
         string memory registryFilename,
+        string memory addressbookFilename,
         bool dryrun,
         bool quiet
-    ) Registry(namespace, registryFilename) SenderCoordinator(senderInitConfigs, namespace, network, dryrun, quiet) {}
+    )
+        Registry(namespace, registryFilename, addressbookFilename)
+        SenderCoordinator(senderInitConfigs, namespace, network, dryrun, quiet)
+    {}
 }

--- a/src/TrebScript.sol
+++ b/src/TrebScript.sol
@@ -46,6 +46,7 @@ abstract contract TrebScript is ConfigurableTrebScript {
             vm.envOr("NAMESPACE", string("default")),
             vm.envString("NETWORK"),
             vm.envOr("REGISTRY_FILE", string(".treb/registry.json")),
+            vm.envOr("ADDRESSBOOK_FILE", string(".treb/addressbook.json")),
             vm.envOr("DRYRUN", false),
             vm.envOr("QUIET", false)
         )

--- a/src/internal/Registry.sol
+++ b/src/internal/Registry.sol
@@ -53,6 +53,9 @@ contract Registry is Script {
     /// @notice The loaded registry JSON content
     string private registryJSON;
 
+    /// @notice The loaded addressbook JSON content
+    string private addressbookJSON;
+
     /// @notice The default namespace/environment for lookups
     string private namespace;
 
@@ -60,14 +63,14 @@ contract Registry is Script {
     string private chainId;
 
     /**
-     * @notice Initializes the registry with a namespace and registry file path
+     * @notice Initializes the registry with a namespace, registry file path, and addressbook file path
      * @param _namespace The default namespace to use for lookups (e.g., "default", "staging", "production")
      * @param _registryJSONFile Path to the registry JSON file (typically ".treb/registry.json")
-     * @dev If the registry file cannot be loaded, the contract will initialize with an empty registry
-     *      and lookups will return address(0). This allows deployment scripts to continue even if
-     *      the registry is not yet populated.
+     * @param _addressbookJSONFile Path to the addressbook JSON file (typically ".treb/addressbook.json")
+     * @dev If the registry or addressbook files cannot be loaded, the contract will initialize with
+     *      empty JSON and lookups for that source will return address(0).
      */
-    constructor(string memory _namespace, string memory _registryJSONFile) {
+    constructor(string memory _namespace, string memory _registryJSONFile, string memory _addressbookJSONFile) {
         chainId = vm.toString(block.chainid);
         namespace = _namespace;
         try vm.readFile(_registryJSONFile) returns (string memory _registryJSON) {
@@ -75,6 +78,12 @@ contract Registry is Script {
         } catch {
             console.log("Registry: failed to load registry from", _registryJSONFile);
             registryJSON = "{}";
+        }
+        try vm.readFile(_addressbookJSONFile) returns (string memory _addressbookJSON) {
+            addressbookJSON = _addressbookJSON;
+        } catch {
+            console.log("Registry: failed to load addressbook from", _addressbookJSONFile);
+            addressbookJSON = "{}";
         }
     }
 
@@ -148,11 +157,38 @@ contract Registry is Script {
         view
         returns (address)
     {
+        address registryResult = _lookupRegistry(_identifier, _env, _chainId);
+        address addressbookResult = _lookupAddressbook(_identifier, _chainId);
+
+        require(
+            registryResult == address(0) || addressbookResult == address(0),
+            string.concat("lookup: '", _identifier, "' found in both registry and addressbook")
+        );
+
+        if (registryResult != address(0)) {
+            return registryResult;
+        }
+        return addressbookResult;
+    }
+
+    function _lookupRegistry(string memory _identifier, string memory _env, string memory _chainId)
+        private
+        view
+        returns (address)
+    {
         string memory jsonPath = string.concat(".", _chainId, ".", _env, "[\"", _identifier, "\"]");
         try vm.parseJsonAddress(registryJSON, jsonPath) returns (address result) {
             return result;
         } catch {
-            console.log("Registry: lookup failed for", _chainId, _env, _identifier);
+            return address(0);
+        }
+    }
+
+    function _lookupAddressbook(string memory _identifier, string memory _chainId) private view returns (address) {
+        string memory jsonPath = string.concat(".", _chainId, "[\"", _identifier, "\"]");
+        try vm.parseJsonAddress(addressbookJSON, jsonPath) returns (address result) {
+            return result;
+        } catch {
             return address(0);
         }
     }

--- a/src/internal/sender/GnosisSafeSender.sol
+++ b/src/internal/sender/GnosisSafeSender.sol
@@ -93,11 +93,11 @@ library GnosisSafe {
             .initialize(
                 _sender.account,
                 Safe.Signer({
-                    signer: _sender.proposer().account,
-                    signerType: signerType,
-                    derivationPath: derivationPath,
-                    privateKey: privateKey
-                })
+                signer: _sender.proposer().account,
+                signerType: signerType,
+                derivationPath: derivationPath,
+                privateKey: privateKey
+            })
             );
     }
 

--- a/src/internal/sender/GnosisSafeSender.sol
+++ b/src/internal/sender/GnosisSafeSender.sol
@@ -93,11 +93,11 @@ library GnosisSafe {
             .initialize(
                 _sender.account,
                 Safe.Signer({
-                signer: _sender.proposer().account,
-                signerType: signerType,
-                derivationPath: derivationPath,
-                privateKey: privateKey
-            })
+                    signer: _sender.proposer().account,
+                    signerType: signerType,
+                    derivationPath: derivationPath,
+                    privateKey: privateKey
+                })
             );
     }
 

--- a/test/QuietMode.t.sol
+++ b/test/QuietMode.t.sol
@@ -139,6 +139,7 @@ contract TestScript is ConfigurableTrebScript {
             "test",
             "sepolia",
             ".test-registry.json",
+            ".test-addressbook.json",
             false, // not dryrun
             _quiet // quiet mode
         )

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -110,8 +110,7 @@ contract RegistryTest is Test {
         // ERC1967Proxy:Counter is only in the registry, not in the addressbook
         registry = new Registry("default", BASIC_REGISTRY, ADDRESSBOOK);
         assertEq(
-            registry.lookup("ERC1967Proxy:Counter", "staging"),
-            address(0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E)
+            registry.lookup("ERC1967Proxy:Counter", "staging"), address(0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E)
         );
     }
 

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -5,6 +5,9 @@ import {Test, console} from "forge-std/Test.sol";
 import {Registry} from "../src/internal/Registry.sol";
 
 contract RegistryTest is Test {
+    string constant BASIC_REGISTRY = "test/fixtures/basic.json";
+    string constant ADDRESSBOOK = "test/fixtures/addressbook.json";
+
     Registry registry;
     uint256 chainId;
 
@@ -21,39 +24,39 @@ contract RegistryTest is Test {
     }
 
     function testLookup() public isolatedEnv("test/fixtures/basic.json", "default") {
-        registry = new Registry("default", "test/fixtures/basic.json");
+        registry = new Registry("default", "test/fixtures/basic.json", "");
         // Test that it returns the correct address from basic.json
         assertEq(registry.lookup("Counter"), address(0x1234567890123456789012345678901234567890));
     }
 
     function testLookupByNamespace() public isolatedEnv("test/fixtures/basic.json", "default") {
-        registry = new Registry("default", "test/fixtures/basic.json");
+        registry = new Registry("default", "test/fixtures/basic.json", "");
         // Test that it returns the correct address for staging
         assertEq(registry.lookup("Counter", "staging"), address(0x2345678901234567890123456789012345678901));
     }
 
     function testLookupNonExistent() public isolatedEnv("test/fixtures/basic.json", "default") {
-        registry = new Registry("default", "test/fixtures/basic.json");
+        registry = new Registry("default", "test/fixtures/basic.json", "");
         // Test that lookup returns address(0) for non-existent
         assertEq(registry.lookup("NonExistent"), address(0));
     }
 
     function testNamespaceOverride() public isolatedEnv("test/fixtures/basic.json", "staging") {
-        Registry stagingRegistry = new Registry("staging", "test/fixtures/basic.json");
+        Registry stagingRegistry = new Registry("staging", "test/fixtures/basic.json", "");
 
         // The staging registry should lookup from staging namespace
         assertEq(stagingRegistry.lookup("Counter"), address(0x2345678901234567890123456789012345678901));
     }
 
     function testMissingDeploymentFile() public isolatedEnv("test/fixtures/non-existent.json", "default") {
-        Registry emptyRegistry = new Registry("default", "test/fixtures/non-existent.json");
+        Registry emptyRegistry = new Registry("default", "test/fixtures/non-existent.json", "");
 
         // Should return address(0) for non-existent deployments
         assertEq(emptyRegistry.lookup("Counter"), address(0));
     }
 
     function testMultipleNamespaces() public isolatedEnv("test/fixtures/duplicate-sid.json", "default") {
-        Registry dupRegistry = new Registry("default", "test/fixtures/duplicate-sid.json");
+        Registry dupRegistry = new Registry("default", "test/fixtures/duplicate-sid.json", "");
 
         // Test that we can access the same identifier in different namespaces
         assertEq(dupRegistry.lookup("Token"), address(0x1111111111111111111111111111111111111111));
@@ -61,13 +64,13 @@ contract RegistryTest is Test {
     }
 
     function testEmptyDeployments() public isolatedEnv("test/fixtures/empty.json", "default") {
-        Registry emptyRegistry = new Registry("default", "test/fixtures/empty.json");
+        Registry emptyRegistry = new Registry("default", "test/fixtures/empty.json", "");
 
         assertEq(emptyRegistry.lookup("Counter"), address(0));
     }
 
     function testLookupWithFullParams() public isolatedEnv("test/fixtures/basic.json", "default") {
-        registry = new Registry("default", "test/fixtures/basic.json");
+        registry = new Registry("default", "test/fixtures/basic.json", "");
 
         // Test the full three-parameter lookup method
         assertEq(registry.lookup("Counter", "default", "31337"), address(0x1234567890123456789012345678901234567890));
@@ -78,11 +81,48 @@ contract RegistryTest is Test {
     }
 
     function testLookupWithPathWithColumns() public isolatedEnv("test/fixtures/basic.json", "default") {
-        registry = new Registry("default", "test/fixtures/basic.json");
+        registry = new Registry("default", "test/fixtures/basic.json", "");
 
         assertEq(
             registry.lookup("ERC1967Proxy:Counter", "staging", "31337"),
             address(0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E)
         );
+    }
+
+    function testLookupFromAddressbook() public {
+        registry = new Registry("default", "", ADDRESSBOOK);
+        assertEq(registry.lookup("Broker"), address(0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB));
+    }
+
+    function testLookupFromAddressbookReturnsZeroForMissing() public {
+        registry = new Registry("default", "", ADDRESSBOOK);
+        assertEq(registry.lookup("NonExistent"), address(0));
+    }
+
+    function testLookupFoundInBothReverts() public {
+        // Counter exists in both basic.json registry and addressbook.json
+        registry = new Registry("default", BASIC_REGISTRY, ADDRESSBOOK);
+        vm.expectRevert("lookup: 'Counter' found in both registry and addressbook");
+        registry.lookup("Counter");
+    }
+
+    function testLookupOnlyInRegistryWithAddressbook() public {
+        // ERC1967Proxy:Counter is only in the registry, not in the addressbook
+        registry = new Registry("default", BASIC_REGISTRY, ADDRESSBOOK);
+        assertEq(
+            registry.lookup("ERC1967Proxy:Counter", "staging"),
+            address(0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E)
+        );
+    }
+
+    function testLookupOnlyInAddressbookWithRegistry() public {
+        // Broker is only in the addressbook, not in the registry
+        registry = new Registry("default", BASIC_REGISTRY, ADDRESSBOOK);
+        assertEq(registry.lookup("Broker"), address(0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB));
+    }
+
+    function testLookupNotFoundInEither() public {
+        registry = new Registry("default", BASIC_REGISTRY, ADDRESSBOOK);
+        assertEq(registry.lookup("DoesNotExist"), address(0));
     }
 }

--- a/test/fixtures/addressbook.json
+++ b/test/fixtures/addressbook.json
@@ -1,0 +1,6 @@
+{
+  "31337": {
+    "Counter": "0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa",
+    "Broker": "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB"
+  }
+}


### PR DESCRIPTION
## Summary
- Extend `Registry` to load an addressbook JSON file (keyed by chain ID) alongside the registry JSON
- `lookup` now searches both sources: reverts if found in both, returns `address(0)` if found in neither, returns the address if found in exactly one
- Add `ADDRESSBOOK_FILE` env var to `TrebScript` (defaults to `.treb/addressbook.json`)
- Add `addressbookFilename` param to `ConfigurableTrebScript`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added addressbook support for address lookups alongside the registry, including duplicate-entry validation.
  * Introduced an environment config for specifying an addressbook file (with a sensible default).

* **Tests**
  * Added addressbook fixtures and new tests covering lookups, precedence, duplicates, and missing entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->