### PR TITLE
feat: add isForkMode to ConfigurableTrebScript

### DIFF
--- a/script/ExampleDeploy.sol
+++ b/script/ExampleDeploy.sol
@@ -31,7 +31,8 @@ contract ExampleDeploy is ConfigurableTrebScript, CreateXScript {
             "example-registry.json", // Registry file
             "example-addressbook.json", // Addressbook file
             false, // Not dry run
-            false // Not quiet mode
+            false, // Not quiet mode
+            false // Not fork mode
         )
     {}
 

--- a/src/ConfigurableTrebScript.sol
+++ b/src/ConfigurableTrebScript.sol
@@ -27,9 +27,12 @@ import {Senders} from "./internal/sender/Senders.sol";
  *          constructor() ConfigurableTrebScript(
  *              _getSenderConfigs(),     // Custom sender configuration
  *              "production",            // Namespace
+ *              "sepolia",               // Network
  *              "deployments.json",      // Registry file
+ *              "addressbook.json",      // Addressbook file
  *              false,                   // Not dry run
- *              false                    // Not quiet mode
+ *              false,                   // Not quiet mode
+ *              false                    // Not fork mode
  *          ) {}
  *
  *          function _getSenderConfigs() internal pure returns (Senders.SenderInitConfig[] memory) {
@@ -39,14 +42,19 @@ import {Senders} from "./internal/sender/Senders.sol";
  *      ```
  */
 abstract contract ConfigurableTrebScript is SenderCoordinator, Registry {
+    /// @notice Whether the script is running in fork mode (against a local anvil fork)
+    bool public isForkMode;
+
     /**
      * @notice Initializes the configurable deployment script with explicit parameters
      * @param senderInitConfigs Array of sender configurations defining available transaction senders
      * @param namespace Deployment namespace (e.g., "default", "staging", "production")
      * @param network Network name
      * @param registryFilename Path to the registry JSON file for deployment lookups
+     * @param addressbookFilename Path to the addressbook JSON file
      * @param dryrun Whether to run in dry-run mode (simulate without executing transactions)
      * @param quiet Whether to suppress internal treb-cli parsing logs (reduces trace pollution)
+     * @param _isForkMode Whether the script is running against a local anvil fork via treb fork mode
      * @dev This constructor provides complete control over all configuration parameters,
      *      making it suitable for use cases where environment variable configuration is not desired.
      */
@@ -57,9 +65,12 @@ abstract contract ConfigurableTrebScript is SenderCoordinator, Registry {
         string memory registryFilename,
         string memory addressbookFilename,
         bool dryrun,
-        bool quiet
+        bool quiet,
+        bool _isForkMode
     )
         Registry(namespace, registryFilename, addressbookFilename)
         SenderCoordinator(senderInitConfigs, namespace, network, dryrun, quiet)
-    {}
+    {
+        isForkMode = _isForkMode;
+    }
 }

--- a/src/TrebScript.sol
+++ b/src/TrebScript.sol
@@ -26,6 +26,7 @@ import {Senders} from "./internal/sender/Senders.sol";
  *      - REGISTRY_FILE: Registry file path (default: ".treb/registry.json")
  *      - DRYRUN: Whether to execute in dry-run mode (default: false)
  *      - QUIET: Whether to suppress internal treb-cli parsing logs (default: false)
+ *      - TREB_FORK_MODE: Whether running against a local anvil fork via treb fork mode (default: false)
  */
 abstract contract TrebScript is ConfigurableTrebScript {
     /**
@@ -48,7 +49,8 @@ abstract contract TrebScript is ConfigurableTrebScript {
             vm.envOr("REGISTRY_FILE", string(".treb/registry.json")),
             vm.envOr("ADDRESSBOOK_FILE", string(".treb/addressbook.json")),
             vm.envOr("DRYRUN", false),
-            vm.envOr("QUIET", false)
+            vm.envOr("QUIET", false),
+            vm.envOr("TREB_FORK_MODE", false)
         )
     {}
 }

--- a/test/QuietMode.t.sol
+++ b/test/QuietMode.t.sol
@@ -141,7 +141,8 @@ contract TestScript is ConfigurableTrebScript {
             ".test-registry.json",
             ".test-addressbook.json",
             false, // not dryrun
-            _quiet // quiet mode
+            _quiet, // quiet mode
+            false // not fork mode
         )
     {}
 


### PR DESCRIPTION
## Summary
- Adds `isForkMode` bool to `ConfigurableTrebScript` constructor parameter
- `TrebScript` reads from `TREB_FORK_MODE` env var (defaults to `false`)
- Updates all callers (`ExampleDeploy.sol`, `QuietMode.t.sol`) with new parameter

## Usage
```solidity
// Automatic via TrebScript (reads TREB_FORK_MODE env var)
contract MyDeploy is TrebScript {
    function run() public {
        if (isForkMode) {
            // fork-specific logic
        }
    }
}

// Manual via ConfigurableTrebScript
constructor() ConfigurableTrebScript(
    configs, "production", "sepolia", "registry.json", "addressbook.json",
    false, false, true // isForkMode
) {}
```

## Companion PR
- treb-cli: https://github.com/trebuchet-org/treb-cli/pull/41

## Test plan
- [x] `forge build` passes
- [x] All existing callers updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)