### PR TITLE
feat: gas-aware Safe transaction batch splitting

### DIFF
--- a/src/internal/sender/GnosisSafeSender.sol
+++ b/src/internal/sender/GnosisSafeSender.sol
@@ -55,6 +55,9 @@ library GnosisSafe {
 
     Vm private constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
 
+    /// @dev Fixed gas overhead per batch for MultiSend encoding + Safe.execTransaction wrapper
+    uint256 private constant BATCH_OVERHEAD = 100_000;
+
     error SafeTransactionValueNotZero(Transaction transaction);
     error InvalidGnosisSafeConfig(string name);
 
@@ -111,9 +114,6 @@ library GnosisSafe {
     function queue(Sender storage _sender, SimulatedTransaction memory _tx) internal {
         _sender.txQueue.push(_tx);
     }
-
-    /// @dev Fixed gas overhead per batch for MultiSend encoding + Safe.execTransaction wrapper
-    uint256 private constant BATCH_OVERHEAD = 100_000;
 
     /**
      * @notice Broadcasts all queued transactions with gas-aware batch splitting
@@ -232,33 +232,6 @@ library GnosisSafe {
     }
 
     /**
-     * @notice Low-level Safe execTransaction call via vm.broadcast
-     * @dev Extracted to reduce stack depth in _executeDirectly
-     */
-    function _execSafeTransaction(
-        Sender storage _sender,
-        address to,
-        bytes memory data,
-        Enum.Operation operation,
-        bytes memory signature
-    ) private {
-        vm.broadcast(_sender.proposer().account);
-        bool success = SafeContract(payable(_sender.account)).execTransaction(
-            to,
-            0, // value
-            data,
-            operation,
-            0, // safeTxGas
-            0, // baseGas
-            0, // gasPrice
-            address(0), // gasToken
-            payable(0), // refundReceiver
-            signature
-        );
-        require(success, "Safe transaction execution failed");
-    }
-
-    /**
      * @notice Checks if the Safe has threshold of 1
      * @param _sender The Safe sender
      * @return True if the Safe has threshold of 1
@@ -304,5 +277,33 @@ library GnosisSafe {
         assembly {
             _gnosisSafeSender.slot := _sender.slot
         }
+    }
+
+    /**
+     * @notice Low-level Safe execTransaction call via vm.broadcast
+     * @dev Extracted to reduce stack depth in _executeDirectly
+     */
+    function _execSafeTransaction(
+        Sender storage _sender,
+        address to,
+        bytes memory data,
+        Enum.Operation operation,
+        bytes memory signature
+    ) private {
+        vm.broadcast(_sender.proposer().account);
+        bool success = SafeContract(payable(_sender.account))
+            .execTransaction(
+                to,
+                0, // value
+                data,
+                operation,
+                0, // safeTxGas
+                0, // baseGas
+                0, // gasPrice
+                address(0), // gasToken
+                payable(0), // refundReceiver
+                signature
+            );
+        require(success, "Safe transaction execution failed");
     }
 }

--- a/src/internal/sender/GnosisSafeSender.sol
+++ b/src/internal/sender/GnosisSafeSender.sol
@@ -112,12 +112,14 @@ library GnosisSafe {
         _sender.txQueue.push(_tx);
     }
 
+    /// @dev Fixed gas overhead per batch for MultiSend encoding + Safe.execTransaction wrapper
+    uint256 private constant BATCH_OVERHEAD = 100_000;
+
     /**
-     * @notice Broadcasts all queued transactions with optional dry-run mode
-     * @dev Collects all queued transactions into a batch proposal for the Safe.
-     *      Validates that transactions don't include ETH transfers (currently unsupported).
-     *      If the Safe has threshold 1 and we have a proposer, executes directly on-chain.
-     *      Otherwise, proposes via Safe API for UI review.
+     * @notice Broadcasts all queued transactions with gas-aware batch splitting
+     * @dev Splits queued transactions into multiple batches if their cumulative gas
+     *      would exceed 50% of the block gas limit. Each batch is broadcast separately
+     *      with sequential Safe nonces managed in-memory.
      * @param _sender The Safe sender
      */
     function broadcast(Sender storage _sender) internal {
@@ -125,83 +127,125 @@ library GnosisSafe {
             return;
         }
 
-        address[] memory targets = new address[](_sender.txQueue.length);
-        bytes[] memory datas = new bytes[](_sender.txQueue.length);
+        uint256 gasThreshold = block.gaslimit * 50 / 100;
+        uint256 nonce = SafeContract(payable(_sender.account)).nonce();
+
+        uint256 batchStart = 0;
+        uint256 batchGas = BATCH_OVERHEAD;
 
         for (uint256 i = 0; i < _sender.txQueue.length; i++) {
-            if (_sender.txQueue[i].transaction.value > 0) {
-                revert SafeTransactionValueNotZero(_sender.txQueue[i].transaction);
+            uint256 txGas = _sender.txQueue[i].gasUsed;
+
+            // If adding this tx would exceed threshold, broadcast current batch first
+            // (but only if current batch is non-empty)
+            if (batchGas + txGas > gasThreshold && i > batchStart) {
+                _broadcastBatch(_sender, batchStart, i, nonce);
+                nonce++;
+                batchStart = i;
+                batchGas = BATCH_OVERHEAD;
             }
-            targets[i] = _sender.txQueue[i].transaction.to;
-            datas[i] = _sender.txQueue[i].transaction.data;
+
+            batchGas += txGas;
         }
 
-        // Check if we can execute directly (threshold = 1)
-        if (isThresholdOne(_sender)) {
-            // Execute directly on-chain
-            _executeDirectly(_sender, targets, datas);
-        } else {
-            // Use Safe API for multi-sig flow
-            bytes32 safeTxHash = _sender.safe().proposeTransactions(targets, datas);
-            // Only emit event if not in quiet mode
-            if (!Senders.registry().quiet) {
-                bytes32[] memory transactionIds = new bytes32[](_sender.txQueue.length);
-                for (uint256 i = 0; i < _sender.txQueue.length; i++) {
-                    transactionIds[i] = _sender.txQueue[i].transactionId;
-                }
-                emit ITrebEvents.SafeTransactionQueued(
-                    safeTxHash, _sender.account, _sender.proposer().account, transactionIds
-                );
-            }
-        }
+        // Broadcast remaining batch
+        _broadcastBatch(_sender, batchStart, _sender.txQueue.length, nonce);
 
         delete _sender.txQueue;
     }
 
     /**
+     * @notice Broadcasts a slice of the transaction queue as a single Safe batch
+     * @dev Handles both threshold-1 (direct execution) and multi-sig (API proposal) paths.
+     *      Validates no value transfers and emits appropriate events per batch.
+     * @param _sender The Safe sender
+     * @param startIdx Start index (inclusive) in txQueue
+     * @param endIdx End index (exclusive) in txQueue
+     * @param nonce Safe nonce to use for this batch
+     */
+    function _broadcastBatch(Sender storage _sender, uint256 startIdx, uint256 endIdx, uint256 nonce) internal {
+        uint256 batchLen = endIdx - startIdx;
+        address[] memory targets = new address[](batchLen);
+        bytes[] memory datas = new bytes[](batchLen);
+        bytes32[] memory transactionIds = new bytes32[](batchLen);
+
+        for (uint256 i = 0; i < batchLen; i++) {
+            SimulatedTransaction storage stx = _sender.txQueue[startIdx + i];
+            if (stx.transaction.value > 0) {
+                revert SafeTransactionValueNotZero(stx.transaction);
+            }
+            targets[i] = stx.transaction.to;
+            datas[i] = stx.transaction.data;
+            transactionIds[i] = stx.transactionId;
+        }
+
+        if (isThresholdOne(_sender)) {
+            bytes32 safeTxHash = _executeDirectly(_sender, targets, datas, nonce);
+            if (!Senders.registry().quiet) {
+                emit ITrebEvents.SafeTransactionExecuted(
+                    safeTxHash, _sender.account, _sender.proposer().account, transactionIds
+                );
+            }
+        } else {
+            bytes32 safeTxHash = _sender.safe().proposeTransactions(targets, datas, nonce);
+            if (!Senders.registry().quiet) {
+                emit ITrebEvents.SafeTransactionQueued(
+                    safeTxHash, _sender.account, _sender.proposer().account, transactionIds
+                );
+            }
+        }
+    }
+
+    /**
      * @notice Executes transactions directly on the Safe when threshold is 1
-     * @dev Uses vm.broadcast to execute the Safe transaction on-chain
+     * @dev Uses vm.broadcast to execute the Safe transaction on-chain.
+     *      The nonce is managed by the caller to support sequential batches.
      * @param _sender The Safe sender
      * @param targets Array of target addresses for the transactions
      * @param datas Array of calldata for the transactions
+     * @param nonce Safe nonce to use for signing and hash computation
+     * @return safeTxHash The hash of the executed Safe transaction
      */
-    function _executeDirectly(Sender storage _sender, address[] memory targets, bytes[] memory datas) internal {
-        SafeContract safeInstance = SafeContract(payable(_sender.account));
-
-        // Get the transaction data based on whether we have single or multiple transactions
+    function _executeDirectly(Sender storage _sender, address[] memory targets, bytes[] memory datas, uint256 nonce)
+        internal
+        returns (bytes32 safeTxHash)
+    {
+        // Resolve to/data/operation based on single vs multi transaction
         address to;
-        uint256 value = 0;
         bytes memory data;
         Enum.Operation operation;
 
         if (targets.length == 1) {
-            // Single transaction
             to = targets[0];
             data = datas[0];
             operation = Enum.Operation.Call;
         } else {
-            // Multiple transactions - use MultiSend
             (to, data) = _sender.safe().getProposeTransactionsTargetAndData(targets, datas);
             operation = Enum.Operation.DelegateCall;
         }
 
-        // Get the transaction hash
-        uint256 nonce = safeInstance.nonce();
-        bytes32 safeTxHash =
-            safeInstance.getTransactionHash(to, value, data, operation, 0, 0, 0, address(0), address(0), nonce);
+        safeTxHash = _sender.safe().getSafeTxHash(to, 0, data, operation, nonce);
 
-        // Sign the transaction with the proposer
-        bytes memory signature = _sender.safe().sign(to, data, operation);
+        // Sign with explicit nonce and execute
+        bytes memory signature = _sender.safe().sign(to, data, operation, nonce);
+        _execSafeTransaction(_sender, to, data, operation, signature);
+    }
 
-        // Execute the transaction using vm.broadcast
-        // The proposer must be an owner of the Safe for this to work
-        address proposerAddress = _sender.proposer().account;
-
-        // Use vm.broadcast to execute as the proposer
-        vm.broadcast(proposerAddress);
-        bool success = safeInstance.execTransaction(
+    /**
+     * @notice Low-level Safe execTransaction call via vm.broadcast
+     * @dev Extracted to reduce stack depth in _executeDirectly
+     */
+    function _execSafeTransaction(
+        Sender storage _sender,
+        address to,
+        bytes memory data,
+        Enum.Operation operation,
+        bytes memory signature
+    ) private {
+        vm.broadcast(_sender.proposer().account);
+        bool success = SafeContract(payable(_sender.account)).execTransaction(
             to,
-            value,
+            0, // value
             data,
             operation,
             0, // safeTxGas
@@ -211,17 +255,7 @@ library GnosisSafe {
             payable(0), // refundReceiver
             signature
         );
-
         require(success, "Safe transaction execution failed");
-
-        // Emit event for tracking
-        if (!Senders.registry().quiet) {
-            bytes32[] memory transactionIds = new bytes32[](_sender.txQueue.length);
-            for (uint256 i = 0; i < _sender.txQueue.length; i++) {
-                transactionIds[i] = _sender.txQueue[i].transactionId;
-            }
-            emit ITrebEvents.SafeTransactionExecuted(safeTxHash, _sender.account, proposerAddress, transactionIds);
-        }
     }
 
     /**

--- a/src/internal/sender/Senders.sol
+++ b/src/internal/sender/Senders.sol
@@ -542,9 +542,13 @@ library Senders {
             // Generate unique transaction ID
             bytes32 transactionId = generateTransactionId();
 
+            uint256 gasBefore = gasleft();
+
             vm.prank(_sender.account);
             (bool success, bytes memory returnData) =
                 _transactions[i].to.call{value: _transactions[i].value}(_transactions[i].data);
+
+            uint256 gasUsed = gasBefore - gasleft();
 
             if (!success) {
                 // Bubble up the revert reason from the failed call
@@ -559,7 +563,8 @@ library Senders {
                 transactionId: transactionId,
                 senderId: _sender.id,
                 sender: _sender.account,
-                returnData: returnData
+                returnData: returnData,
+                gasUsed: gasUsed
             });
 
             // Only emit events if not in quiet mode

--- a/src/internal/types.sol
+++ b/src/internal/types.sol
@@ -13,6 +13,7 @@ struct SimulatedTransaction {
     address sender;
     bytes returnData;
     Transaction transaction;
+    uint256 gasUsed;
 }
 
 library SenderTypes {

--- a/test/GasBatchSplitting.t.sol
+++ b/test/GasBatchSplitting.t.sol
@@ -72,6 +72,7 @@ contract GasBatchSplittingTest is Test {
 
         harness = new SendersTestHarness(configs);
         vm.makePersistent(address(harness));
+        vm.makePersistent(address(target));
 
         vm.deal(vm.addr(0x54321), 10 ether);
         vm.selectFork(harness.getExecutionFork());

--- a/test/GasBatchSplitting.t.sol
+++ b/test/GasBatchSplitting.t.sol
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {Senders} from "../src/internal/sender/Senders.sol";
+import {GnosisSafe} from "../src/internal/sender/GnosisSafeSender.sol";
+import {SenderTypes, Transaction, SimulatedTransaction} from "../src/internal/types.sol";
+import {SendersTestHarness} from "./helpers/SendersTestHarness.sol";
+import {ITrebEvents} from "../src/internal/ITrebEvents.sol";
+import {Safe} from "safe-smart-account/Safe.sol";
+import {SafeProxyFactory} from "safe-smart-account/proxies/SafeProxyFactory.sol";
+
+contract MockGasTarget {
+    uint256 public storedValue;
+
+    function setValue(uint256 _value) external returns (uint256) {
+        storedValue = _value;
+        return _value;
+    }
+}
+
+contract GasBatchSplittingTest is Test {
+    MockGasTarget target;
+    SendersTestHarness harness;
+    Safe safeThreshold1;
+
+    string constant PROPOSER = "proposer";
+    string constant SAFE_T1 = "safe-t1";
+    bytes32 constant salt = keccak256(abi.encode("gas-batch-salt"));
+
+    function setUp() public {
+        target = new MockGasTarget{salt: salt}();
+
+        // Deploy Safe with threshold 1
+        Safe safeMasterCopy = new Safe{salt: salt}();
+        SafeProxyFactory factory = new SafeProxyFactory{salt: salt}();
+
+        address[] memory owners = new address[](1);
+        owners[0] = vm.addr(0x54321);
+
+        bytes memory initializer = abi.encodeWithSelector(
+            Safe.setup.selector,
+            owners,
+            1,
+            address(0),
+            "",
+            address(0),
+            address(0),
+            0,
+            payable(0)
+        );
+
+        safeThreshold1 = Safe(payable(factory.createProxyWithNonce(address(safeMasterCopy), initializer, 1)));
+
+        Senders.SenderInitConfig[] memory configs = new Senders.SenderInitConfig[](2);
+
+        configs[0] = Senders.SenderInitConfig({
+            name: PROPOSER,
+            account: vm.addr(0x54321),
+            senderType: SenderTypes.InMemory,
+            canBroadcast: true,
+            config: abi.encode(0x54321)
+        });
+
+        configs[1] = Senders.SenderInitConfig({
+            name: SAFE_T1,
+            account: address(safeThreshold1),
+            senderType: SenderTypes.GnosisSafe,
+            canBroadcast: true,
+            config: abi.encode(PROPOSER)
+        });
+
+        harness = new SendersTestHarness(configs);
+        vm.makePersistent(address(harness));
+
+        vm.deal(vm.addr(0x54321), 10 ether);
+        vm.selectFork(harness.getExecutionFork());
+        vm.deal(vm.addr(0x54321), 10 ether);
+        vm.selectFork(harness.getSimulationFork());
+    }
+
+    // ---- Helper to create SimulatedTransactions with controlled gasUsed ----
+
+    function _makeSimTx(uint256 gasUsed, uint256 txId) internal view returns (SimulatedTransaction memory) {
+        return SimulatedTransaction({
+            transactionId: bytes32(txId),
+            senderId: keccak256(abi.encodePacked(SAFE_T1)),
+            sender: address(safeThreshold1),
+            returnData: "",
+            transaction: Transaction({
+                to: address(target),
+                data: abi.encodeWithSelector(MockGasTarget.setValue.selector, txId),
+                value: 0
+            }),
+            gasUsed: gasUsed
+        });
+    }
+
+    // ---- Phase 1: Gas metering tests ----
+
+    function test_gasUsedIsRecorded() public {
+        Transaction memory txn = Transaction({
+            to: address(target),
+            data: abi.encodeWithSelector(MockGasTarget.setValue.selector, 42),
+            value: 0
+        });
+
+        SimulatedTransaction memory simTx = harness.execute(SAFE_T1, txn);
+        assertGt(simTx.gasUsed, 0, "gasUsed should be > 0");
+    }
+
+    function test_gasUsedRecordedForBatch() public {
+        Transaction[] memory txns = new Transaction[](3);
+        for (uint256 i = 0; i < 3; i++) {
+            txns[i] = Transaction({
+                to: address(target),
+                data: abi.encodeWithSelector(MockGasTarget.setValue.selector, i + 1),
+                value: 0
+            });
+        }
+
+        SimulatedTransaction[] memory simTxs = harness.execute(SAFE_T1, txns);
+
+        for (uint256 i = 0; i < simTxs.length; i++) {
+            assertGt(simTxs[i].gasUsed, 0, "Each tx should have gasUsed > 0");
+        }
+    }
+
+    // ---- Phase 2: Batch splitting tests using manual SimulatedTransactions ----
+
+    function test_singleBatch_allUnderThreshold() public {
+        // 3 small txs well under the gas threshold → single batch
+        for (uint256 i = 0; i < 3; i++) {
+            harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(100_000, i + 1));
+        }
+
+        // Expect exactly 1 SafeTransactionExecuted event
+        vm.expectEmit(false, true, true, false);
+        emit ITrebEvents.SafeTransactionExecuted(
+            bytes32(0), address(safeThreshold1), vm.addr(0x54321), new bytes32[](3)
+        );
+
+        harness.broadcastSafeSender(SAFE_T1);
+        assertEq(target.storedValue(), 3);
+    }
+
+    function test_multiBatch_splitsByGasThreshold() public {
+        // block.gaslimit is typically 30M on the fork
+        // threshold = 30M * 50 / 100 = 15M
+        // BATCH_OVERHEAD = 100k
+        //
+        // 6 txs with 5M gasUsed each:
+        //   Batch 1: overhead(100k) + tx1(5M) = 5.1M, + tx2(5M) = 10.1M, + tx3(5M) = 15.1M > 15M → split
+        //   Batch 1 = [tx1, tx2] (10.1M)
+        //   Batch 2: overhead(100k) + tx3(5M) = 5.1M, + tx4(5M) = 10.1M, + tx5(5M) = 15.1M > 15M → split
+        //   Batch 2 = [tx3, tx4] (10.1M)
+        //   Batch 3: overhead(100k) + tx5(5M) = 5.1M, + tx6(5M) = 10.1M
+        //   Batch 3 = [tx5, tx6] (10.1M)
+        //
+        // Expect 3 SafeTransactionExecuted events
+
+        for (uint256 i = 0; i < 6; i++) {
+            harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(5_000_000, i + 1));
+        }
+
+        // Record logs to count events
+        vm.recordLogs();
+        harness.broadcastSafeSender(SAFE_T1);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 executedSig = ITrebEvents.SafeTransactionExecuted.selector;
+
+        uint256 batchCount = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == executedSig) {
+                batchCount++;
+            }
+        }
+
+        assertEq(batchCount, 3, "Should produce exactly 3 batches");
+        // Last tx sets value to 6
+        assertEq(target.storedValue(), 6);
+    }
+
+    function test_singleLargeTx_exceedsThreshold_stillExecutes() public {
+        // A single tx with gasUsed > threshold should still go through as its own batch
+        // threshold is ~15M, use 20M for the single tx
+        harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(20_000_000, 42));
+
+        vm.expectEmit(false, true, true, false);
+        emit ITrebEvents.SafeTransactionExecuted(
+            bytes32(0), address(safeThreshold1), vm.addr(0x54321), new bytes32[](1)
+        );
+
+        harness.broadcastSafeSender(SAFE_T1);
+        assertEq(target.storedValue(), 42);
+    }
+
+    function test_mixedGas_correctBatchBoundaries() public {
+        // threshold = 15M, overhead = 100k
+        // tx1: 7M  → batch gas: 100k + 7M = 7.1M
+        // tx2: 7M  → batch gas: 7.1M + 7M = 14.1M (under 15M)
+        // tx3: 2M  → batch gas: 14.1M + 2M = 16.1M > 15M → split before tx3
+        //   Batch 1 = [tx1, tx2]
+        // tx3: 2M  → new batch: 100k + 2M = 2.1M
+        // tx4: 2M  → batch gas: 2.1M + 2M = 4.1M
+        // tx5: 2M  → batch gas: 4.1M + 2M = 6.1M
+        //   Batch 2 = [tx3, tx4, tx5]
+        // Expect 2 batches
+
+        harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(7_000_000, 1));
+        harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(7_000_000, 2));
+        harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(2_000_000, 3));
+        harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(2_000_000, 4));
+        harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(2_000_000, 5));
+
+        vm.recordLogs();
+        harness.broadcastSafeSender(SAFE_T1);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 executedSig = ITrebEvents.SafeTransactionExecuted.selector;
+
+        uint256 batchCount = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == executedSig) {
+                batchCount++;
+            }
+        }
+
+        assertEq(batchCount, 2, "Should produce exactly 2 batches");
+        assertEq(target.storedValue(), 5);
+    }
+
+    function test_emptyQueueDoesNotRevert() public {
+        harness.broadcastSafeSender(SAFE_T1);
+    }
+
+    function test_zeroGasUsed_allInOneBatch() public {
+        // If gasUsed is 0 for all txs (e.g., not metered), they should all fit in one batch
+        for (uint256 i = 0; i < 10; i++) {
+            harness.queueSimulatedTransaction(SAFE_T1, _makeSimTx(0, i + 1));
+        }
+
+        vm.recordLogs();
+        harness.broadcastSafeSender(SAFE_T1);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 executedSig = ITrebEvents.SafeTransactionExecuted.selector;
+
+        uint256 batchCount = 0;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics[0] == executedSig) {
+                batchCount++;
+            }
+        }
+
+        assertEq(batchCount, 1, "Zero-gas txs should all fit in one batch");
+    }
+
+    // ---- End-to-end test via normal execute flow ----
+
+    function test_endToEnd_normalFlow() public {
+        // Execute through normal flow — gasUsed will be small, all fit in one batch
+        Transaction[] memory txns = new Transaction[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            txns[i] = Transaction({
+                to: address(target),
+                data: abi.encodeWithSelector(MockGasTarget.setValue.selector, i + 1),
+                value: 0
+            });
+        }
+
+        SimulatedTransaction[] memory simTxs = harness.execute(SAFE_T1, txns);
+
+        // Verify gas was recorded
+        uint256 totalGas = 0;
+        for (uint256 i = 0; i < simTxs.length; i++) {
+            assertGt(simTxs[i].gasUsed, 0);
+            totalGas += simTxs[i].gasUsed;
+        }
+        assertLt(totalGas, block.gaslimit * 50 / 100, "Total gas under threshold for single batch");
+
+        // Broadcast via normal flow
+        vm.expectEmit(false, true, true, false);
+        emit ITrebEvents.SafeTransactionExecuted(
+            bytes32(0), address(safeThreshold1), vm.addr(0x54321), new bytes32[](5)
+        );
+
+        harness.broadcastAll();
+        assertEq(target.storedValue(), 5);
+    }
+}

--- a/test/GasBatchSplitting.t.sol
+++ b/test/GasBatchSplitting.t.sol
@@ -39,15 +39,7 @@ contract GasBatchSplittingTest is Test {
         owners[0] = vm.addr(0x54321);
 
         bytes memory initializer = abi.encodeWithSelector(
-            Safe.setup.selector,
-            owners,
-            1,
-            address(0),
-            "",
-            address(0),
-            address(0),
-            0,
-            payable(0)
+            Safe.setup.selector, owners, 1, address(0), "", address(0), address(0), 0, payable(0)
         );
 
         safeThreshold1 = Safe(payable(factory.createProxyWithNonce(address(safeMasterCopy), initializer, 1)));
@@ -89,9 +81,7 @@ contract GasBatchSplittingTest is Test {
             sender: address(safeThreshold1),
             returnData: "",
             transaction: Transaction({
-                to: address(target),
-                data: abi.encodeWithSelector(MockGasTarget.setValue.selector, txId),
-                value: 0
+                to: address(target), data: abi.encodeWithSelector(MockGasTarget.setValue.selector, txId), value: 0
             }),
             gasUsed: gasUsed
         });
@@ -101,9 +91,7 @@ contract GasBatchSplittingTest is Test {
 
     function test_gasUsedIsRecorded() public {
         Transaction memory txn = Transaction({
-            to: address(target),
-            data: abi.encodeWithSelector(MockGasTarget.setValue.selector, 42),
-            value: 0
+            to: address(target), data: abi.encodeWithSelector(MockGasTarget.setValue.selector, 42), value: 0
         });
 
         SimulatedTransaction memory simTx = harness.execute(SAFE_T1, txn);
@@ -114,9 +102,7 @@ contract GasBatchSplittingTest is Test {
         Transaction[] memory txns = new Transaction[](3);
         for (uint256 i = 0; i < 3; i++) {
             txns[i] = Transaction({
-                to: address(target),
-                data: abi.encodeWithSelector(MockGasTarget.setValue.selector, i + 1),
-                value: 0
+                to: address(target), data: abi.encodeWithSelector(MockGasTarget.setValue.selector, i + 1), value: 0
             });
         }
 
@@ -265,9 +251,7 @@ contract GasBatchSplittingTest is Test {
         Transaction[] memory txns = new Transaction[](5);
         for (uint256 i = 0; i < 5; i++) {
             txns[i] = Transaction({
-                to: address(target),
-                data: abi.encodeWithSelector(MockGasTarget.setValue.selector, i + 1),
-                value: 0
+                to: address(target), data: abi.encodeWithSelector(MockGasTarget.setValue.selector, i + 1), value: 0
             });
         }
 

--- a/test/helpers/SendersTestHarness.sol
+++ b/test/helpers/SendersTestHarness.sol
@@ -40,16 +40,8 @@ contract SendersTestHarness is SenderCoordinator {
                 safeClient.instance().urls[block.chainid] = "https://localhost";
                 safeClient.instance().multiSendCallOnly[block.chainid] = multiSendCallOnly;
 
-                // Mock Safe contract calls
-                address safeAddress = sender.account;
-                vm.mockCall(safeAddress, abi.encodeWithSignature("nonce()"), abi.encode(uint256(0)));
-                vm.mockCall(
-                    safeAddress,
-                    abi.encodeWithSignature(
-                        "getTransactionHash(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,uint256)"
-                    ),
-                    abi.encode(bytes32(keccak256("mock-tx-hash")))
-                );
+                // Make Safe contract persistent across forks
+                vm.makePersistent(sender.account);
             }
         }
     }
@@ -240,6 +232,22 @@ contract SendersTestHarness is SenderCoordinator {
 
     function _derivedSalt(string memory _name, bytes32 _baseSalt) public view returns (bytes32) {
         return Senders.get(_name)._derivedSalt(_baseSalt);
+    }
+
+    // ************* Gas Batch Testing Helpers ************* //
+
+    function queueSimulatedTransaction(
+        string memory _name,
+        SimulatedTransaction memory _tx
+    ) public {
+        GnosisSafe.Sender storage gnosisSafeSender = Senders.get(_name).gnosisSafe();
+        gnosisSafeSender.txQueue.push(_tx);
+    }
+
+    function broadcastSafeSender(string memory _name) public {
+        vm.selectFork(Senders.registry().executionFork);
+        Senders.get(_name).gnosisSafe().broadcast();
+        vm.selectFork(Senders.registry().simulationFork);
     }
 
     // ************* Registry Helpers ************* //

--- a/test/helpers/SendersTestHarness.sol
+++ b/test/helpers/SendersTestHarness.sol
@@ -236,10 +236,7 @@ contract SendersTestHarness is SenderCoordinator {
 
     // ************* Gas Batch Testing Helpers ************* //
 
-    function queueSimulatedTransaction(
-        string memory _name,
-        SimulatedTransaction memory _tx
-    ) public {
+    function queueSimulatedTransaction(string memory _name, SimulatedTransaction memory _tx) public {
         GnosisSafe.Sender storage gnosisSafeSender = Senders.get(_name).gnosisSafe();
         gnosisSafeSender.txQueue.push(_tx);
     }


### PR DESCRIPTION
## Summary
- Adds gas metering during transaction simulation (`gasUsed` field on `SimulatedTransaction`)
- Refactors `GnosisSafe.broadcast()` to split batches when cumulative gas exceeds 50% of `block.gaslimit`
- Manages Safe nonces in-memory across multiple batches (depends on safe-utils PR trebuchet-org/safe-utils#3)
- Removes Safe nonce/hash mocks from test harness in favor of `vm.makePersistent`

## Details
- **Gas metering**: Wraps `vm.prank` + `call` with `gasleft()` before/after in `Senders.simulate()`
- **Batch splitting**: 50% block gas limit threshold with 100k overhead per batch for MultiSend encoding
- **Nonce management**: Reads nonce once at broadcast start, increments per batch, passes explicitly to `sign()` and `proposeTransactions()`
- **Stack depth**: Extracted `_execSafeTransaction()` private helper to avoid stack-too-deep

## Dependencies
- trebuchet-org/safe-utils#3 (nonce-accepting overloads for `sign` and `proposeTransactions`)

## WIP
- `test/GasBatchSplitting.t.sol` has some assertions that need fixing (fork state isolation issue with `storedValue()` checks)

## Test plan
- [x] All 114 existing tests pass
- [ ] Fix fork-state assertions in GasBatchSplitting tests
- [ ] Integration testing in downstream repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent gas-aware batching that splits queued transactions to avoid block gas limit failures.
  * Transaction simulations now record and surface per-transaction gas usage.

* **Tests**
  * Added end-to-end and unit tests validating gas metering, batch-splitting behavior, edge cases, and no-op/boundary scenarios.

* **Chores**
  * Updated a vendored submodule reference (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->