### PR TITLE
feat: extract gas threshold for Monad per-tx gas limit

### DIFF
--- a/src/internal/sender/GnosisSafeSender.sol
+++ b/src/internal/sender/GnosisSafeSender.sol
@@ -155,19 +155,6 @@ library GnosisSafe {
     }
 
     /**
-     * @notice Get gas threshold for batch transactions
-     * @dev Half the block gas limit, except on Monad (mainnet and testnet) where
-     *      there is a 25M per-transaction gas limit.
-     * @return Gas threshold in gas units
-     */
-    function gasThreshold() internal view returns (uint256) {
-        if (block.chainid == 143 || block.chainid == 10143) {
-            return 25_000_000;
-        }
-        return block.gaslimit / 2;
-    }
-
-    /**
      * @notice Broadcasts a slice of the transaction queue as a single Safe batch
      * @dev Handles both threshold-1 (direct execution) and multi-sig (API proposal) paths.
      *      Validates no value transfers and emits appropriate events per batch.
@@ -242,6 +229,19 @@ library GnosisSafe {
         // Sign with explicit nonce and execute
         bytes memory signature = _sender.safe().sign(to, data, operation, nonce);
         _execSafeTransaction(_sender, to, data, operation, signature);
+    }
+
+    /**
+     * @notice Get gas threshold for batch transactions
+     * @dev Half the block gas limit, except on Monad (mainnet and testnet) where
+     *      there is a 25M per-transaction gas limit.
+     * @return Gas threshold in gas units
+     */
+    function gasThreshold() internal view returns (uint256) {
+        if (block.chainid == 143 || block.chainid == 10143) {
+            return 25_000_000;
+        }
+        return block.gaslimit / 2;
     }
 
     /**

--- a/src/internal/sender/GnosisSafeSender.sol
+++ b/src/internal/sender/GnosisSafeSender.sol
@@ -116,6 +116,19 @@ library GnosisSafe {
     }
 
     /**
+     * @notice Get gas threshold for batch transactions
+     * @dev Half block, apart from Monad where we have 30M per transaction limit
+     */
+    function gasThreshold() internal view returns (uint256) {
+        if (block.chainid == 143) {
+            // Monad per transaction limit is 30M
+            return 30e6;
+        } else {
+            return block.gaslimit / 2;
+        }
+    }
+
+    /**
      * @notice Broadcasts all queued transactions with gas-aware batch splitting
      * @dev Splits queued transactions into multiple batches if their cumulative gas
      *      would exceed 50% of the block gas limit. Each batch is broadcast separately
@@ -127,7 +140,7 @@ library GnosisSafe {
             return;
         }
 
-        uint256 gasThreshold = block.gaslimit * 50 / 100;
+        uint256 _gasThreshold = gasThreshold();
         uint256 nonce = SafeContract(payable(_sender.account)).nonce();
 
         uint256 batchStart = 0;
@@ -138,7 +151,7 @@ library GnosisSafe {
 
             // If adding this tx would exceed threshold, broadcast current batch first
             // (but only if current batch is non-empty)
-            if (batchGas + txGas > gasThreshold && i > batchStart) {
+            if (batchGas + txGas > _gasThreshold && i > batchStart) {
                 _broadcastBatch(_sender, batchStart, i, nonce);
                 nonce++;
                 batchStart = i;

--- a/src/internal/sender/GnosisSafeSender.sol
+++ b/src/internal/sender/GnosisSafeSender.sol
@@ -122,7 +122,7 @@ library GnosisSafe {
     function gasThreshold() internal view returns (uint256) {
         if (block.chainid == 143) {
             // Monad per transaction limit is 30M
-            return 30e6;
+            return 25e6;
         } else {
             return block.gaslimit / 2;
         }

--- a/src/internal/sender/GnosisSafeSender.sol
+++ b/src/internal/sender/GnosisSafeSender.sol
@@ -116,19 +116,6 @@ library GnosisSafe {
     }
 
     /**
-     * @notice Get gas threshold for batch transactions
-     * @dev Half block, apart from Monad where we have 30M per transaction limit
-     */
-    function gasThreshold() internal view returns (uint256) {
-        if (block.chainid == 143) {
-            // Monad per transaction limit is 30M
-            return 25e6;
-        } else {
-            return block.gaslimit / 2;
-        }
-    }
-
-    /**
      * @notice Broadcasts all queued transactions with gas-aware batch splitting
      * @dev Splits queued transactions into multiple batches if their cumulative gas
      *      would exceed 50% of the block gas limit. Each batch is broadcast separately
@@ -165,6 +152,19 @@ library GnosisSafe {
         _broadcastBatch(_sender, batchStart, _sender.txQueue.length, nonce);
 
         delete _sender.txQueue;
+    }
+
+    /**
+     * @notice Get gas threshold for batch transactions
+     * @dev Half the block gas limit, except on Monad (mainnet and testnet) where
+     *      there is a 25M per-transaction gas limit.
+     * @return Gas threshold in gas units
+     */
+    function gasThreshold() internal view returns (uint256) {
+        if (block.chainid == 143 || block.chainid == 10143) {
+            return 25_000_000;
+        }
+        return block.gaslimit / 2;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Extracts gas threshold calculation into a dedicated `gasThreshold()` function in the `GnosisSafe` library
- Handles Monad's 30M per-transaction gas limit (chain ID 143) separately from the default block-gas-based threshold (`block.gaslimit / 2`)

## Test plan
- [ ] Verify compilation passes (`forge build`)
- [ ] Verify existing Safe batch splitting tests still pass
- [ ] Test on Monad testnet that batches respect the 30M gas limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved gas management: replaced static threshold with a dynamic, chain-aware gas threshold and per-batch reuse to optimize transaction processing. This reduces unnecessary failures and improves reliability and efficiency across different blockchain networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->